### PR TITLE
webkitRelativePath: Remove 'shortest common ancestor' requirement (Fixes #18)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -313,7 +313,8 @@ directory rather than a file or files. When specified, the behavior on
 the selection of a directory is as if all files with that directory as
 an ancestor were selected. In addition, the
 {{File/webkitRelativePath}} property of each {{File}} is set to a
-[=relative path=] from the selected directory to the file.
+[=relative path=] starting from (and including) the selected directory
+to the file.
 
 <aside class=example>
   Given the following directory structure:
@@ -323,18 +324,18 @@ an ancestor were selected. In addition, the
       to_upload/
         a/
           b/
-            c/
-              1.txt
-              2.txt
-            3.txt
+            1.txt
+            2.txt
+          3.txt
+      not_uploaded.txt
   </xmp>
 
   If the `to_upload` directory was selected, then
   {{HTMLInputElement/files}} would include:
 
-  * An entry with {{File/name}} == "`1.txt`" and {{File/webkitRelativePath}} == "`a/b/c/1.txt`"
-  * An entry with {{File/name}} == "`2.txt`" and {{File/webkitRelativePath}} == "`a/b/c/2.txt`"
-  * An entry with {{File/name}} == "`3.txt`" and {{File/webkitRelativePath}} == "`a/b/3.txt`"
+  * An entry with {{File/name}} == "`1.txt`" and {{File/webkitRelativePath}} == "`to_upload/a/b/1.txt`"
+  * An entry with {{File/name}} == "`2.txt`" and {{File/webkitRelativePath}} == "`to_upload/a/b/2.txt`"
+  * An entry with {{File/name}} == "`3.txt`" and {{File/webkitRelativePath}} == "`to_upload/a/3.txt`"
 
 </aside>
 
@@ -1010,6 +1011,7 @@ And thanks to
 Ali Alabbas,
 Philip Jägenstedt,
 Marijn Kruisselbrink,
+Olli Pettay,
 and
-Olli Pettay
+Kent Tamura
 for suggestions, reviews, and other feedback.

--- a/index.bs
+++ b/index.bs
@@ -313,10 +313,7 @@ directory rather than a file or files. When specified, the behavior on
 the selection of a directory is as if all files with that directory as
 an ancestor were selected. In addition, the
 {{File/webkitRelativePath}} property of each {{File}} is set to a
-[=relative path=] from the shortest common ancestor directory of all
-selected files to that file, including that ancestor in the path.
-(Therefore this may be a subdirectory of the selected directory
-rather than the directory itself.)
+[=relative path=] from the selected directory to the file.
 
 <aside class=example>
   Given the following directory structure:
@@ -327,18 +324,17 @@ rather than the directory itself.)
         a/
           b/
             c/
-              d/
-                1.txt
-                2.txt
-              3.txt
+              1.txt
+              2.txt
+            3.txt
   </xmp>
 
   If the `to_upload` directory was selected, then
   {{HTMLInputElement/files}} would include:
 
-  * An entry with {{File/name}} == "`1.txt`" and {{File/webkitRelativePath}} ==  "`c/d/1.txt`"
-  * An entry with {{File/name}} == "`2.txt`" and {{File/webkitRelativePath}} == "`c/d/2.txt`"
-  * An entry with {{File/name}} == "`3.txt`" and {{File/webkitRelativePath}} == "`c/3.txt`"
+  * An entry with {{File/name}} == "`1.txt`" and {{File/webkitRelativePath}} == "`a/b/c/1.txt`"
+  * An entry with {{File/name}} == "`2.txt`" and {{File/webkitRelativePath}} == "`a/b/c/2.txt`"
+  * An entry with {{File/name}} == "`3.txt`" and {{File/webkitRelativePath}} == "`a/b/3.txt`"
 
 </aside>
 


### PR DESCRIPTION
Not ready for landing - needs test updates.

https://github.com/WICG/entries-api/issues/18

cc: @tkent-google