### PR TITLE
Update to Web IDL changes to optional dictionary defaulting

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -601,11 +601,11 @@ function getParentAsPromise(entry) {
 <xmp class=idl>
 interface FileSystemDirectoryEntry : FileSystemEntry {
     FileSystemDirectoryReader createReader();
-    void getFile(optional USVString? path = null,
+    void getFile(optional USVString? path,
                  optional FileSystemFlags options = {},
                  optional FileSystemEntryCallback successCallback,
                  optional ErrorCallback errorCallback);
-    void getDirectory(optional USVString? path = null,
+    void getDirectory(optional USVString? path,
                       optional FileSystemFlags options = {},
                       optional FileSystemEntryCallback successCallback,
                       optional ErrorCallback errorCallback);
@@ -653,7 +653,7 @@ invoked, must run the following steps:
 
 1. [=Queue a task=] to run the following substeps:
 
-    1. If |path| is null let |path| be the empty string.
+    1. If |path| is undefined or null let |path| be the empty string.
 
     2. If |path| is not a [=valid path=], [=invoke=]
         |errorCallback| (if given) with a newly [=exception/created=]
@@ -695,7 +695,7 @@ invoked, must run the following steps:
 
 1. [=Queue a task=] to run the following substeps:
 
-    1. If |path| is null let |path| be the empty string.
+    1. If |path| is undefined or null let |path| be the empty string.
 
     2. If |path| is not a [=valid path=], [=invoke=]
         |errorCallback| (if given) with a newly [=exception/created=]

--- a/index.bs
+++ b/index.bs
@@ -601,12 +601,12 @@ function getParentAsPromise(entry) {
 <xmp class=idl>
 interface FileSystemDirectoryEntry : FileSystemEntry {
     FileSystemDirectoryReader createReader();
-    void getFile(optional USVString? path,
-                 optional FileSystemFlags options,
+    void getFile(optional USVString? path = null,
+                 optional FileSystemFlags options = {},
                  optional FileSystemEntryCallback successCallback,
                  optional ErrorCallback errorCallback);
-    void getDirectory(optional USVString? path,
-                      optional FileSystemFlags options,
+    void getDirectory(optional USVString? path = null,
+                      optional FileSystemFlags options = {},
                       optional FileSystemEntryCallback successCallback,
                       optional ErrorCallback errorCallback);
 };
@@ -653,7 +653,7 @@ invoked, must run the following steps:
 
 1. [=Queue a task=] to run the following substeps:
 
-    1. If |path| is undefined or null let |path| be the empty string.
+    1. If |path| is null let |path| be the empty string.
 
     2. If |path| is not a [=valid path=], [=invoke=]
         |errorCallback| (if given) with a newly [=exception/created=]
@@ -695,7 +695,7 @@ invoked, must run the following steps:
 
 1. [=Queue a task=] to run the following substeps:
 
-    1. If |path| is undefined or null let |path| be the empty string.
+    1. If |path| is null let |path| be the empty string.
 
     2. If |path| is not a [=valid path=], [=invoke=]
         |errorCallback| (if given) with a newly [=exception/created=]


### PR DESCRIPTION
Optional dictionaries must be defaulted with {}. Since these cases
follow an optional DOMString? path argument, that must have a default
value as well so make it null.

Fixes #31