### PR TITLE
Make async steps explicitly "in parallel" with queued callbacks

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -38,6 +38,9 @@ spec: ecma262; urlPrefix: https://tc39.github.io/ecma262/
     type: dfn
         text: Promise; url: #sec-promise-objects
         text: AsyncIterator; url: #sec-asynciterator-interface
+spec: fileapi; urlPrefix: https://w3c.github.io/FileAPI/
+    type: dfn
+        text: file reading task source; url: #fileReadingTaskSource
 </pre>
 
 <img id="speclogo" src="logo-folder.svg" alt="logo" width="100" height="100">
@@ -492,6 +495,11 @@ callback ErrorCallback = undefined (DOMException err);
 An {{ErrorCallback}} function is used for operations that may return an
 error asynchronously.
 
+<div class=issue>
+  The [=/task source=] used for [=/queue a task|tasks that are queued=] in steps below is not defined. Chromium-based browsers appear to use the following:
+    * The [=/file reading task source=] [[FileAPI]], for {{FileSystemDirectoryReader/readEntries()}} success and error callbacks.
+    * An unnamed task source used in cases where the specification does not identify the task source.
+</div>
 
 
 <!-- ============================================================ -->
@@ -528,7 +536,7 @@ The <dfn attribute for=FileSystemEntry>filesystem</dfn> getter steps are to retu
 
 The <dfn method for=FileSystemEntry>getParent(|successCallback|, |errorCallback|)</dfn> method steps are:
 
-1. [=Queue a task=] to perform the following steps:
+1. [=In parallel=], run these steps:
 
     1. Let |path| be the result of [=resolving a
         relative path=] with [=/this=]'s [=full path=] and '..'.
@@ -536,7 +544,7 @@ The <dfn method for=FileSystemEntry>getParent(|successCallback|, |errorCallback|
     1. Let |item| be the result of [=evaluating a
         path=] with [=/this=]'s [=entry/root=] and |path|.
 
-    1. If |item| is failure, [=invoke=]
+    1. If |item| is failure, [=queue a task=] to [=invoke=]
         |errorCallback| (if given) with a newly [=exception/created=]
         "{{NotFoundError}}" {{DOMException}}, and abort these steps.
 
@@ -544,7 +552,7 @@ The <dfn method for=FileSystemEntry>getParent(|successCallback|, |errorCallback|
         [=directory/name=] as [=entry/name=] and |path| as [=full
         path=].
 
-    1. [=Invoke=] |successCallback| with a new
+    1. [=Queue a task=] to [=invoke=] |successCallback| with a new
         {{FileSystemDirectoryEntry}} object associated with |entry|.
 
 </div>
@@ -632,16 +640,16 @@ The <dfn method for=FileSystemDirectoryEntry>createReader()</dfn> method steps a
 
 The <dfn method for=FileSystemDirectoryEntry>getFile(|path|, |options|, |successCallback|, |errorCallback|)</dfn> method steps are:
 
-1. [=Queue a task=] to run the following steps:
+1. [=In parallel=], run these steps:
 
     1. If |path| is undefined or null let |path| be the empty string.
 
-    1. If |path| is not a [=valid path=], [=invoke=]
+    1. If |path| is not a [=valid path=], [=queue a task=] to [=invoke=]
         |errorCallback| (if given) with a newly [=exception/created=]
         "{{TypeMismatchError}}" {{DOMException}}, and abort these steps.
 
     1. If |options|'s {{FileSystemFlags/create}} member is true,
-        [=invoke=] |errorCallback| (if given) with a
+        [=queue a task=] to [=invoke=] |errorCallback| (if given) with a
         newly [=exception/created=] "{{SecurityError}}" {{DOMException}}, and abort
         these steps.
 
@@ -652,18 +660,18 @@ The <dfn method for=FileSystemDirectoryEntry>getFile(|path|, |options|, |success
     1. Let |item| be the result of [=evaluating a
         path=] with [=/this=]'s [=entry/root=] and |path|.
 
-    1. If |item| is failure, [=invoke=]
+    1. If |item| is failure, [=queue a task=] to [=invoke=]
         |errorCallback| (if given) with a newly [=exception/created=]
         "{{NotFoundError}}" {{DOMException}}, and abort these steps.
 
-    1. If |item| is not a [=file=], [=invoke=]
+    1. If |item| is not a [=file=], [=queue a task=] to [=invoke=]
         |errorCallback| (if given) with a newly [=exception/created=]
         "{{TypeMismatchError}}" {{DOMException}}, and abort these steps.
 
     1. Let |entry| be a new [=file entry=] with |item|'s [=file/name=]
         as [=entry/name=] and |path| as [=full path=].
 
-    1. [=Invoke=] |successCallback| (if given) with a new
+    1. [=Queue a task=] to [=invoke=] |successCallback| (if given) with a new
         {{FileSystemFileEntry}} object associated with |entry|.
 
 </div>
@@ -672,16 +680,16 @@ The <dfn method for=FileSystemDirectoryEntry>getFile(|path|, |options|, |success
 
 The <dfn method for=FileSystemDirectoryEntry>getDirectory(|path|, |options|, |successCallback|, |errorCallback|)</dfn> method steps are:
 
-1. [=Queue a task=] to run the following steps:
+1. [=In parallel=], run these steps:
 
     1. If |path| is undefined or null let |path| be the empty string.
 
-    1. If |path| is not a [=valid path=], [=invoke=]
+    1. If |path| is not a [=valid path=], [=queue a task=] to [=invoke=]
         |errorCallback| (if given) with a newly [=exception/created=]
         "{{TypeMismatchError}}" {{DOMException}}, and abort these steps.
 
     1. If |options|'s {{FileSystemFlags/create}} member is true,
-        [=invoke=] |errorCallback| (if given) with a
+        [=queue a task=] to [=invoke=] |errorCallback| (if given) with a
         newly [=exception/created=] "{{SecurityError}}" {{DOMException}}, and abort
         these steps.
 
@@ -692,7 +700,7 @@ The <dfn method for=FileSystemDirectoryEntry>getDirectory(|path|, |options|, |su
     1. Let |item| be the result of [=evaluating a
         path=] with [=/this=]'s [=entry/root=] and |path|.
 
-    1. If |item| is failure, [=invoke=]
+    1. If |item| is failure, [=queue a task=] to [=invoke=]
         |errorCallback| (if given) with a newly [=exception/created=]
         "{{NotFoundError}}" {{DOMException}}, and abort these steps.
 
@@ -704,7 +712,7 @@ The <dfn method for=FileSystemDirectoryEntry>getDirectory(|path|, |options|, |su
         [=directory/name=] as [=entry/name=] and |path| as [=full
         path=].
 
-    1. [=invoke=] |successCallback| (if given) with a new
+    1. [=Queue a task=] to [=invoke=] |successCallback| (if given) with a new
         {{FileSystemDirectoryEntry}} associated with |entry|.
 
 </div>
@@ -762,7 +770,7 @@ The <dfn method for=FileSystemDirectoryEntry>readEntries(|successCallback|, |err
 
 1. Set [=/this=]'s [=FileSystemDirectoryReader/reading flag=] to true.
 
-1. [=Queue a task=] to perform the following steps:
+1. [=In parallel=], run these steps:
 
     1. Set [=/this=]'s [=FileSystemDirectoryReader/reading flag=] to false.
 
@@ -770,13 +778,13 @@ The <dfn method for=FileSystemDirectoryEntry>readEntries(|successCallback|, |err
 
         1. Let |dir| be the result of [=evaluating a path=] with [=/this=]'s [=FileSystemDirectoryReader/entry=]'s [=entry/root=] and [=full path=].
 
-        1. If |dir| is failure, then set [=/this=]'s [=FileSystemDirectoryReader/reader error=] to a newly [=exception/created=] "{{NotFoundError}}" {{DOMException}}, [=invoke=] |errorCallback| (if given) with [=FileSystemDirectoryReader/reader error=], and abort these steps.
+        1. If |dir| is failure, then set [=/this=]'s [=FileSystemDirectoryReader/reader error=] to a newly [=exception/created=] "{{NotFoundError}}" {{DOMException}}, [=queue a task=] to [=invoke=] |errorCallback| (if given) with [=FileSystemDirectoryReader/reader error=], and abort these steps.
 
         1. Set [=/this=]'s [=FileSystemDirectoryReader/directory=] to |dir|.
 
     1. Let |entries| be a non-zero number of entries from [=/this=]'s [=FileSystemDirectoryReader/directory=] that have not yet been produced by this {{FileSystemDirectoryReader}}, if any.
 
-    1. If the previous step failed (for example, the [=directory=] was deleted or permission is denied), then set [=/this=]'s [=FileSystemDirectoryReader/reader error=] to an appropriate {{DOMException}}, [=invoke=] |errorCallback| (if given) with [=FileSystemDirectoryReader/reader error=], and abort these steps.
+    1. If the previous step failed (for example, the [=directory=] was deleted or permission is denied), then set [=/this=]'s [=FileSystemDirectoryReader/reader error=] to an appropriate {{DOMException}}, [=queue a task=] to [=invoke=] |errorCallback| (if given) with [=FileSystemDirectoryReader/reader error=], and abort these steps.
 
     1. If |entries| is empty, set [=/this=]'s [=FileSystemDirectoryReader/done flag=] to true.
 
@@ -891,21 +899,21 @@ A {{FileSystemFileEntry}}'s associated [=entry=] is a [=file entry=].
 
 The <dfn method for=FileSystemFileEntry>file(|successCallback|, |errorCallback|)</dfn> method steps are:
 
-1. [=Queue a task=] to perform the following steps:
+1. [=In parallel=], run these steps:
 
     1. Let |item| be the result of [=evaluating a
         path=] with [=/this=]'s [=entry/root=] and [=full
         path=].
 
-    1. If |item| is failure, [=invoke=]
+    1. If |item| is failure, [=queue a task=] to [=invoke=]
         |errorCallback| (if given) with a newly [=exception/created=]
         "{{NotFoundError}}" {{DOMException}}, and abort these steps.
 
-    1. If |item| is a [=directory=], [=invoke=]
+    1. If |item| is a [=directory=], [=queue a task=] to [=invoke=]
         |errorCallback| (if given) with a newly [=exception/created=]
         "{{TypeMismatchError}}" {{DOMException}}, and abort these steps.
 
-    1. [=invoke=] |successCallback| with a new {{File}}
+    1. [=Queue a task=] to [=invoke=] |successCallback| with a new {{File}}
         object representing |item|.
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -38,9 +38,6 @@ spec: ecma262; urlPrefix: https://tc39.github.io/ecma262/
     type: dfn
         text: Promise; url: #sec-promise-objects
         text: AsyncIterator; url: #sec-asynciterator-interface
-spec: fileapi; urlPrefix: https://w3c.github.io/FileAPI/
-    type: dfn
-        text: file reading task source; url: #fileReadingTaskSource
 </pre>
 
 <img id="speclogo" src="logo-folder.svg" alt="logo" width="100" height="100">
@@ -497,8 +494,8 @@ error asynchronously.
 
 <div class=issue>
   The [=/task source=] used for [=/queue a task|tasks that are queued=] in steps below is not defined. Chromium-based browsers appear to use the following:
-    * The [=/file reading task source=] [[FileAPI]], for {{FileSystemDirectoryReader/readEntries()}} success and error callbacks.
-    * An unnamed task source used in cases where the specification does not identify the task source.
+    * The <a href="https://w3c.github.io/FileAPI/#fileReadingTaskSource">file reading task source</a> [[FileAPI]], for {{FileSystemDirectoryReader/readEntries()}} success and error callbacks. (The Chromium implementation calls this `TaskType::kFileReading`.)
+    * The [=/DOM manipulation task source=] [[HTML]] elsewhere. (The Chromium implementation uses `TaskType::kMiscPlatformAPI` which targets the same underlying task queue as `TaskType::kDOMManipulation`.)
 </div>
 
 

--- a/index.bs
+++ b/index.bs
@@ -769,23 +769,51 @@ The <dfn method for=FileSystemDirectoryEntry>readEntries(|successCallback|, |err
 
 1. [=In parallel=], run these steps:
 
-    1. Set [=/this=]'s [=FileSystemDirectoryReader/reading flag=] to false.
-
     1. If [=/this=]'s [=FileSystemDirectoryReader/directory=] is null, then:
 
         1. Let |dir| be the result of [=evaluating a path=] with [=/this=]'s [=FileSystemDirectoryReader/entry=]'s [=entry/root=] and [=full path=].
 
-        1. If |dir| is failure, then set [=/this=]'s [=FileSystemDirectoryReader/reader error=] to a newly [=exception/created=] "{{NotFoundError}}" {{DOMException}}, [=queue a task=] to [=invoke=] |errorCallback| (if given) with [=FileSystemDirectoryReader/reader error=], and abort these steps.
+        1. If |dir| is failure, then:
+
+            1. [=Queue a task=] to run these steps:
+
+                1. Let |error| be a newly [=exception/created=] "{{NotFoundError}}" {{DOMException}}.
+
+                1. Set [=/this=]'s [=FileSystemDirectoryReader/reader error=] to |error|.
+
+                1. Set [=/this=]'s [=FileSystemDirectoryReader/reading flag=] to false.
+
+                1. [=Invoke=] |errorCallback| (if given) with |error|.
+
+            1. Abort these steps.
 
         1. Set [=/this=]'s [=FileSystemDirectoryReader/directory=] to |dir|.
 
     1. Let |entries| be a non-zero number of entries from [=/this=]'s [=FileSystemDirectoryReader/directory=] that have not yet been produced by this {{FileSystemDirectoryReader}}, if any.
 
-    1. If the previous step failed (for example, the [=directory=] was deleted or permission is denied), then set [=/this=]'s [=FileSystemDirectoryReader/reader error=] to an appropriate {{DOMException}}, [=queue a task=] to [=invoke=] |errorCallback| (if given) with [=FileSystemDirectoryReader/reader error=], and abort these steps.
+    1. If the previous step failed (for example, the [=directory=] was deleted or permission is denied), then:
 
-    1. If |entries| is empty, set [=/this=]'s [=FileSystemDirectoryReader/done flag=] to true.
+        1. [=Queue a task=] to run these steps:
 
-    1. [=Invoke=] |successCallback| with |entries|.
+            1. Let |error| be a an appropriate {{DOMException}}.
+
+            1. Set [=/this=]'s [=FileSystemDirectoryReader/reader error=] to |error|.
+
+            1. Set [=/this=]'s [=FileSystemDirectoryReader/reading flag=] to false.
+
+            1. [=Invoke=] |errorCallback| (if given) with [=FileSystemDirectoryReader/reader error=].
+
+        1. Abort these steps.
+
+    1. [=Queue a task=] to run these steps:
+
+        1. If |entries| is empty, then set [=/this=]'s [=FileSystemDirectoryReader/done flag=] to true.
+
+        1. Set [=/this=]'s [=FileSystemDirectoryReader/reading flag=] to false.
+
+        1. [=Invoke=] |successCallback| with |entries|.
+
+NOTE: The use of the the [=FileSystemDirectoryReader/reading flag=] prevents multiple copies of the [=in parallel=] steps above from executing simultaneously. This obviates the need to specify a [=parallel queue=].
 
 </div>
 


### PR DESCRIPTION
The previous text described async operations by starting off with "queue a task" then just describing the remaining behavior synchronously, including invoking callbacks.

It is more accurate to describe the async operations as starting off "in parallel", with any success/error callbacks being invoked by a queued task.

Note that the task source remains implied rather than explicit, although it is called out with a new issue.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/entries-api/pull/41.html" title="Last updated on Jul 5, 2023, 11:32 PM UTC (d213f8e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/entries-api/41/1d69132...d213f8e.html" title="Last updated on Jul 5, 2023, 11:32 PM UTC (d213f8e)">Diff</a>